### PR TITLE
Corrected links to Swift version and platform compatibility badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Swift runtime for Fastly Compute@Edge
 
-[![Compatibility Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FAndrewBarba%2FCompute%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/AndrewBarba/swift-compute-runtime) [![Platform Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FAndrewBarba%2FCompute%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/AndrewBarba/swift-compute-runtime)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fswift-cloud%2FCompute%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/swift-cloud/Compute) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fswift-cloud%2FCompute%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/swift-cloud/Compute)
 
 ## Getting Started
 


### PR DESCRIPTION
Hey Andrew! These were pointing at the old repository.

<img width="528" alt="Screenshot 2022-12-21 at 10 01 08@2x" src="https://user-images.githubusercontent.com/5180/208877706-1013480e-bcae-46e4-97b1-65720068b73c.png">
