### PR TITLE
feat: add fastly device lookup

### DIFF
--- a/Sources/Compute/Fastly/FastlyDevice.swift
+++ b/Sources/Compute/Fastly/FastlyDevice.swift
@@ -1,0 +1,35 @@
+//
+//  FastlyDevice.swift
+//
+//
+//  Created by Andrew Barba on 3/19/24.
+//
+
+import ComputeRuntime
+
+extension Fastly {
+    public struct Device: Sendable {
+
+        public struct DeviceLookup: Codable, Sendable {
+            public let name: String?
+            public let brand: String?
+            public let model: String?
+            public let hardwareType: String?
+            public let isDesktop: Bool?
+            public let isGameConsole: Bool?
+            public let isMediaPlayer: Bool?
+            public let isMobile: Bool?
+            public let isSmartTV: Bool?
+            public let isTablet: Bool?
+            public let isTouchscreen: Bool?
+        }
+
+        public static func lookup(userAgent: String) throws -> DeviceLookup {
+            return try wasiDecode(maxBufferLength: maxIpLookupLength) {
+                fastly_device__device_detection_lookup(userAgent, userAgent.utf8.count, $0, $1, &$2)
+            }
+        }
+
+        private init() {}
+    }
+}

--- a/Sources/Compute/Fastly/FastlyStubs.swift
+++ b/Sources/Compute/Fastly/FastlyStubs.swift
@@ -202,4 +202,12 @@ func fastly_cache__cache_get_body(
 
 func fastly_cache__cache_transaction_cancel(_ handle: WasiHandle) -> Int32 { fatalError() }
 
+func fastly_device__device_detection_lookup(
+    _ user_agent: UnsafePointer<CChar>!,
+    _ user_agent_len: Int,
+    _ buf: UnsafeMutablePointer<CChar>!,
+    _ buf_len: Int,
+    _ nwritten: UnsafeMutablePointer<Int>!
+) -> Int32 { fatalError() }
+
 #endif

--- a/Sources/ComputeRuntime/include/ComputeRuntime.h
+++ b/Sources/ComputeRuntime/include/ComputeRuntime.h
@@ -335,5 +335,11 @@ int fastly_cache__cache_get_body(WasiHandle handle, uint32_t options_mask,
                                  CacheGetBodyConfig *config,
                                  WasiHandle *ret);
 
+/* FASTLY_DEVICE */
+
+WASM_IMPORT("fastly_device_detection", "lookup")
+int fastly_device__device_detection_lookup(const char *user_agent, size_t user_agent_len, const char *buf,
+                                           size_t buf_len, size_t *nwritten);
+
 #pragma GCC diagnostic pop
 #endif /* ComputeRuntime_h */


### PR DESCRIPTION
Adds support for Fastly's new device lookup API

```swift
try await onIncomingRequest { req, res in
    let userAgent = req.headers[.userAgent]!
    let device = try Fastly.Device.lookup(userAgent: userAgent)
}
```